### PR TITLE
Bumped version number in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ their contents.
 
 ## Installation
 
-In bundler: `gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'`
+In bundler: `gem 'wikidata-client', '~> 0.0.8', require: 'wikidata'`
 
 Otherwise: `gem install wikidata-client`
 


### PR DESCRIPTION
Sorry if this is too minor, but I noticed the version numbers were mismatched in the README file.