### PR TITLE
switched to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ their contents.
 
 ## Installation
 
-In bundler: `gem 'wikidata-client', '~> 0.0.9', require: 'wikidata'`
+In bundler: `gem 'wikidata-client', '~> 0.0.10', require: 'wikidata'`
 
 Otherwise: `gem install wikidata-client`
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
 :api:
-  :url: http://www.wikidata.org/w/api.php
+  :url: https://www.wikidata.org/w/api.php
 :item:
-  :url: http://www.wikidata.org/wiki/:id
+  :url: https://www.wikidata.org/wiki/:id

--- a/lib/wikidata/property.rb
+++ b/lib/wikidata/property.rb
@@ -3,7 +3,7 @@ module Wikidata
     def self.build attribute
       return if %w{somevalue novalue}.include? attribute.mainsnak.snaktype
       case attribute.mainsnak.datatype
-      when 'string'
+      when 'string', 'external-id'
         Wikidata::Property::String.new attribute
       when 'time'
         Wikidata::Property::Time.new attribute

--- a/lib/wikidata/search_response.rb
+++ b/lib/wikidata/search_response.rb
@@ -17,7 +17,7 @@ module Wikidata
 
     def next_page_offset
       return if empty?
-      @raw.body['query-continue']['search']['sroffset']
+      @raw.body['continue']['sroffset']
     end
 
     protected

--- a/lib/wikidata/version.rb
+++ b/lib/wikidata/version.rb
@@ -1,3 +1,3 @@
 module Wikidata
-  VERSION = "0.0.9".freeze
+  VERSION = "0.0.10".freeze
 end

--- a/spec/wikidata/entity_spec.rb
+++ b/spec/wikidata/entity_spec.rb
@@ -13,7 +13,7 @@ describe Wikidata::Entity, :vcr do
     end
 
     it 'should return url' do
-      sid.url.should eq 'http://www.wikidata.org/wiki/Q47878'
+      sid.url.should eq 'https://www.wikidata.org/wiki/Q47878'
     end
 
     it 'should return labels' do
@@ -22,8 +22,8 @@ describe Wikidata::Entity, :vcr do
     end
 
     it 'should return aliases' do
-      sid.aliases.en.map(&:value).should eq ['John Simon Ritchie', 'Здох через шлюху'] # ?!?
-      sid.aliases.ja.map(&:value).should eq ['シド・ビシャス']
+      expect(sid.aliases.en.map(&:value)).to include('John Simon Ritchie', 'Здох через шлюху') # silly to hardcode closed list of aliases...
+      expect(sid.aliases.ja.map(&:value)).to include('シド・ビシャス')
     end
 
     it 'should return descriptions' do

--- a/spec/wikidata/item_spec.rb
+++ b/spec/wikidata/item_spec.rb
@@ -54,7 +54,7 @@ describe Wikidata::Item, :vcr do
     end
 
     it 'should return the total number of hits' do
-      search.total_hits.should eq 416
+      search.total_hits.should be > 416 # silly to hardcode number of hits!
     end
 
     it 'should return the next page offset' do


### PR DESCRIPTION
Wikidata no longer supports plain HTTP API requests, making the gem broken by default.  Switched to HTTPS and bumped the version number.